### PR TITLE
guard use of thread stuff properly

### DIFF
--- a/src/armci_internals.h
+++ b/src/armci_internals.h
@@ -78,6 +78,7 @@ typedef struct {
   int           noncollective_groups;   /* Use noncollective group creation algorithm                           */
   int           cache_rank_translation; /* Enable caching of translation between absolute and group ranks       */
   int           verbose;                /* ARMCI should produce extra status output                             */
+  int           thread_level;           /* THREAD_{SINGLE,FUNNELED,SERIALIZED,MULTIPLE} ala MPI                 */
 #ifdef HAVE_PTHREADS
   int           progress_thread;        /* Create progress thread                                               */
   int           progress_usleep;        /* Argument to usleep() to throttling polling                           */

--- a/src/init_finalize.c
+++ b/src/init_finalize.c
@@ -93,24 +93,25 @@ int PARMCI_Init_thread(int armci_requested) {
     int mpi_is_init, mpi_is_fin;
     MPI_Initialized(&mpi_is_init);
     MPI_Finalized(&mpi_is_fin);
-    if (!mpi_is_init || mpi_is_fin) 
+    if (!mpi_is_init || mpi_is_fin) {
       ARMCII_Error("MPI must be initialized before calling ARMCI_Init");
+    }
   }
 
   /* Check for MPI thread-support */
   {
-    int mpi_provided;
-    MPI_Query_thread(&mpi_provided);
-
-    if (mpi_provided<armci_requested)
-      ARMCII_Error("MPI thread level below ARMCI thread level!");
-  }
-
-#ifdef HAVE_PTHREADS
-  /* Check progress thread settings */
-  {
     int mpi_thread_level;
     MPI_Query_thread(&mpi_thread_level);
+
+    if (mpi_thread_level<armci_requested) {
+      ARMCII_Error("MPI thread level below ARMCI thread level!");
+    }
+
+    ARMCII_GLOBAL_STATE.thread_level = armci_requested;
+
+#ifdef HAVE_PTHREADS
+
+    /* Check progress thread settings */
 
     ARMCII_GLOBAL_STATE.progress_thread    = ARMCII_Getenv_bool("ARMCI_PROGRESS_THREAD", 0);
     ARMCII_GLOBAL_STATE.progress_usleep    = ARMCII_Getenv_int("ARMCI_PROGRESS_USLEEP", 0);
@@ -128,15 +129,6 @@ int PARMCI_Init_thread(int armci_requested) {
     }
   }
 #endif
-
-  /* Check for MPI thread-support */
-  {
-    int mpi_provided;
-    MPI_Query_thread(&mpi_provided);
-
-    if (mpi_provided<armci_requested)
-      ARMCII_Error("MPI thread level below ARMCI thread level!");
-  }
 
   /* Set defaults */
 #ifdef ARMCI_GROUP

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -46,8 +46,10 @@ static pthread_mutex_t armci_mutex_hdl_mutex = PTHREAD_MUTEX_INITIALIZER;
 int PARMCI_Create_mutexes(int count) {
 
 #ifdef HAVE_PTHREADS
-  int ptrc = pthread_mutex_lock(&armci_mutex_hdl_mutex);
-  ARMCII_Assert(ptrc == 0);
+  if (ARMCII_GLOBAL_STATE.thread_level == MPI_THREAD_MULTIPLE) {
+    int ptrc = pthread_mutex_lock(&armci_mutex_hdl_mutex);
+    ARMCII_Assert(ptrc == 0);
+  }
 #endif
 
   if (armci_mutex_hdl != NULL) {
@@ -59,8 +61,10 @@ int PARMCI_Create_mutexes(int count) {
   int rc = ((armci_mutex_hdl != NULL) ? 0 : 1);
 
 #ifdef HAVE_PTHREADS
-  ptrc = pthread_mutex_unlock(&armci_mutex_hdl_mutex);
-  ARMCII_Assert(ptrc == 0);
+  if (ARMCII_GLOBAL_STATE.thread_level == MPI_THREAD_MULTIPLE) {
+    int ptrc = pthread_mutex_unlock(&armci_mutex_hdl_mutex);
+    ARMCII_Assert(ptrc == 0);
+  }
 #endif
 
   return rc;
@@ -82,8 +86,10 @@ int PARMCI_Create_mutexes(int count) {
 int PARMCI_Destroy_mutexes(void) {
 
 #ifdef HAVE_PTHREADS
-  int ptrc = pthread_mutex_lock(&armci_mutex_hdl_mutex);
-  ARMCII_Assert(ptrc == 0);
+  if (ARMCII_GLOBAL_STATE.thread_level == MPI_THREAD_MULTIPLE) {
+    int ptrc = pthread_mutex_lock(&armci_mutex_hdl_mutex);
+    ARMCII_Assert(ptrc == 0);
+  }
 #endif
 
   if (armci_mutex_hdl == NULL) {
@@ -94,8 +100,10 @@ int PARMCI_Destroy_mutexes(void) {
   armci_mutex_hdl = NULL;
 
 #ifdef HAVE_PTHREADS
-  ptrc = pthread_mutex_unlock(&armci_mutex_hdl_mutex);
-  ARMCII_Assert(ptrc == 0);
+  if (ARMCII_GLOBAL_STATE.thread_level == MPI_THREAD_MULTIPLE) {
+    int ptrc = pthread_mutex_unlock(&armci_mutex_hdl_mutex);
+    ARMCII_Assert(ptrc == 0);
+  }
 #endif
 
   return err;
@@ -120,8 +128,10 @@ int PARMCI_Destroy_mutexes(void) {
 void PARMCI_Lock(int mutex, int proc) {
 
 #ifdef HAVE_PTHREADS
-  int ptrc = pthread_mutex_lock(&armci_mutex_hdl_mutex);
-  ARMCII_Assert(ptrc == 0);
+  if (ARMCII_GLOBAL_STATE.thread_level == MPI_THREAD_MULTIPLE) {
+    int ptrc = pthread_mutex_lock(&armci_mutex_hdl_mutex);
+    ARMCII_Assert(ptrc == 0);
+  }
 #endif
 
   if (armci_mutex_hdl == NULL) {
@@ -131,8 +141,10 @@ void PARMCI_Lock(int mutex, int proc) {
   ARMCIX_Lock_hdl(armci_mutex_hdl, mutex, proc);
 
 #ifdef HAVE_PTHREADS
-  ptrc = pthread_mutex_unlock(&armci_mutex_hdl_mutex);
-  ARMCII_Assert(ptrc == 0);
+  if (ARMCII_GLOBAL_STATE.thread_level == MPI_THREAD_MULTIPLE) {
+    int ptrc = pthread_mutex_unlock(&armci_mutex_hdl_mutex);
+    ARMCII_Assert(ptrc == 0);
+  }
 #endif
 }
 
@@ -155,8 +167,10 @@ void PARMCI_Lock(int mutex, int proc) {
 void PARMCI_Unlock(int mutex, int proc) {
 
 #ifdef HAVE_PTHREADS
-  int ptrc = pthread_mutex_lock(&armci_mutex_hdl_mutex);
-  ARMCII_Assert(ptrc == 0);
+  if (ARMCII_GLOBAL_STATE.thread_level == MPI_THREAD_MULTIPLE) {
+    int ptrc = pthread_mutex_lock(&armci_mutex_hdl_mutex);
+    ARMCII_Assert(ptrc == 0);
+  }
 #endif
 
   if (armci_mutex_hdl == NULL) {
@@ -166,7 +180,9 @@ void PARMCI_Unlock(int mutex, int proc) {
   ARMCIX_Unlock_hdl(armci_mutex_hdl, mutex, proc);
 
 #ifdef HAVE_PTHREADS
-  ptrc = pthread_mutex_unlock(&armci_mutex_hdl_mutex);
-  ARMCII_Assert(ptrc == 0);
+  if (ARMCII_GLOBAL_STATE.thread_level == MPI_THREAD_MULTIPLE) {
+    int ptrc = pthread_mutex_unlock(&armci_mutex_hdl_mutex);
+    ARMCII_Assert(ptrc == 0);
+  }
 #endif
 }


### PR DESCRIPTION
- add missing preprocessor guards on pthread API usage
- add runtime guards on use of pthread mutex i.e. limit to MPI_THREAD_MULTIPLE