### PR TITLE
add memdev API

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ libarmci_la_SOURCES = src/buffer.c        \
                       src/vector_nb.c     \
                       src/init_finalize.c \
                       src/conflict_tree.c \
+                      src/armci-memdev.c  \
                       src/parmci.c
 
 libarmci_la_LDFLAGS = -version-info $(libarmci_abi_version)

--- a/src/armci-memdev.c
+++ b/src/armci-memdev.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019. See COPYRIGHT in top-level directory.
+ */
+
+#include <armci.h>
+#include <armci_internals.h>
+
+/* -- begin weak symbols block -- */
+#if defined(HAVE_PRAGMA_WEAK)
+#  pragma weak ARMCI_Malloc_memdev = PARMCI_Malloc_memdev
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#  pragma _HP_SECONDARY_DEF PARMCI_Malloc_memdev ARMCI_Malloc_memdev
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#  pragma _CRI duplicate ARMCI_Malloc_memdev as PARMCI_Malloc_memdev
+#endif
+/* -- end weak symbols block -- */
+int PARMCI_Malloc_memdev(void **ptr_arr, armci_size_t bytes, const char* device)
+{
+    return ARMCI_Malloc_group(ptr_arr, bytes, &ARMCI_GROUP_WORLD);
+}
+
+/* -- begin weak symbols block -- */
+#if defined(HAVE_PRAGMA_WEAK)
+#  pragma weak ARMCI_Malloc_group_memdev = PARMCI_Malloc_group_memdev
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#  pragma _HP_SECONDARY_DEF PARMCI_Malloc_group_memdev ARMCI_Malloc_group_memdev
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#  pragma _CRI duplicate ARMCI_Malloc_group_memdev as PARMCI_Malloc_group_memdev
+#endif
+/* -- end weak symbols block -- */
+int PARMCI_Malloc_group_memdev(void **ptr_arr, armci_size_t bytes, ARMCI_Group *group, const char *device)
+{
+    return ARMCI_Malloc_group(ptr_arr, bytes, group);
+}
+
+/* -- begin weak symbols block -- */
+#if defined(HAVE_PRAGMA_WEAK)
+#  pragma weak ARMCI_Free_memdev = PARMCI_Free_memdev
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#  pragma _HP_SECONDARY_DEF PARMCI_Free_memdev ARMCI_Free_memdev
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#  pragma _CRI duplicate ARMCI_Free_memdev as PARMCI_Free_memdev
+#endif
+/* -- end weak symbols block -- */
+int PARMCI_Free_memdev(void *ptr)
+{
+    return ARMCI_Free(ptr);
+}

--- a/src/armci.h
+++ b/src/armci.h
@@ -289,4 +289,14 @@ int     PARMCI_Rmw(int op, void *ploc, void *prem, int value, int proc);
 void    parmci_msg_barrier(void);
 void    parmci_msg_group_barrier(ARMCI_Group *group);
 
+/* new memdev related to SICM but undocumented */
+
+int ARMCI_Malloc_memdev(void **ptr_arr, armci_size_t bytes, const char* device);
+int ARMCI_Malloc_group_memdev(void **ptr_arr, armci_size_t bytes, ARMCI_Group *group, const char *device);
+int ARMCI_Free_memdev(void *ptr);
+
+int PARMCI_Malloc_memdev(void **ptr_arr, armci_size_t bytes, const char* device);
+int PARMCI_Malloc_group_memdev(void **ptr_arr, armci_size_t bytes, ARMCI_Group *group, const char *device);
+int PARMCI_Free_memdev(void *ptr);
+
 #endif /* _ARMCI_H_ */

--- a/src/parmci.c
+++ b/src/parmci.c
@@ -47,6 +47,21 @@ int ARMCI_Free(void *ptr) {
   return PARMCI_Free(ptr);
 }
 
+#pragma weak ARMCI_Malloc_memdev
+int ARMCI_Malloc_memdev(void **base_ptrs, armci_size_t size, const char *device) {
+  return PARMCI_Malloc_memdev(base_ptrs, size, device);
+}
+
+#pragma weak ARMCI_Malloc_group_memdev
+int ARMCI_Malloc_group_memdev(void **base_ptrs, armci_size_t size, ARMCI_Group *group, const char *device) {
+  return PARMCI_Malloc_group_memdev(base_ptrs, size, group, device);
+}
+
+#pragma weak ARMCI_Free_memdev
+int ARMCI_Free_memdev(void *ptr) {
+  return PARMCI_Free_memdev(ptr);
+}
+
 #pragma weak ARMCI_Malloc_local
 void *ARMCI_Malloc_local(armci_size_t size) {
   return PARMCI_Malloc_local(size);


### PR DESCRIPTION
no-op implementation, which is what GA appears to be using right now.
there is no documentation of this so i will be implemented using the
ComEx source as the spec, whenever we bother to do that.

This resolves https://github.com/pmodels/armci-mpi/issues/28

Signed-off-by: Hammond, Jeff R <jeff.r.hammond@intel.com>