### PR TITLE
fix unitialized usage issues - part 1

### DIFF
--- a/src/gmr.c
+++ b/src/gmr.c
@@ -34,6 +34,9 @@ gmr_t *gmr_create(gmr_size_t local_size, void **base_ptrs, ARMCI_Group *group) {
   ARMCII_Assert(local_size >= 0);
   ARMCII_Assert(group != NULL);
 
+  MPI_Comm_rank(group->comm, &alloc_me);
+  MPI_Comm_size(group->comm, &alloc_nproc);
+
   /* determine if the GMR construction is pointless and exit early */
   {
     gmr_size_t max_local_size;
@@ -49,8 +52,6 @@ gmr_t *gmr_create(gmr_size_t local_size, void **base_ptrs, ARMCI_Group *group) {
     }
   }
 
-  MPI_Comm_rank(group->comm, &alloc_me);
-  MPI_Comm_size(group->comm, &alloc_nproc);
   MPI_Comm_rank(ARMCI_GROUP_WORLD.comm, &world_me);
   MPI_Comm_size(ARMCI_GROUP_WORLD.comm, &world_nproc);
 
@@ -167,7 +168,7 @@ gmr_t *gmr_create(gmr_size_t local_size, void **base_ptrs, ARMCI_Group *group) {
                    mreg->window);
 
   {
-    int unified;
+    int unified = 0;
     void    *attr_ptr;
     int     *attr_val;
     int      attr_flag;
@@ -192,7 +193,6 @@ gmr_t *gmr_create(gmr_size_t local_size, void **base_ptrs, ARMCI_Group *group) {
     } else {
       if (world_me==0) {
         printf("MPI_WIN_MODEL attribute missing \n");
-        unified = 0;
       }
     }
     if (!unified && (ARMCII_GLOBAL_STATE.shr_buf_method == ARMCII_SHR_BUF_NOGUARD) ) {


### PR DESCRIPTION
the `alloc_nproc` issue causes the following error, which is now fixed.

```
jehammond@Jeffs-NVIDIA-MacBook-Air build % mpirun -n 2 ./tests/test_malloc
Starting ARMCI memory allocation test with 2 processes
 + allocation 0
 + allocation 1
 + allocation 2
 + allocation 3
 + allocation 4
 + allocation 5
 + allocation 6
 + allocation 7
 + allocation 8
 + allocation 9
 + allocation 10
 + allocation 11
 + allocation 12
 + allocation 13
 + allocation 14
 + allocation 15
 + allocation 16
 + allocation 17
 + allocation 18
 + allocation 19
 + allocation 20
 + allocation 21
 + allocation 22
 + allocation 23
 + allocation 24
 + allocation 25
 + allocation 26
 + allocation 27
 + allocation 28
 + allocation 29
 + allocation 30
 + allocation 31
 + allocation 32
 + allocation 33
 + allocation 34
 + allocation 35
 + allocation 36
 + allocation 37
 + allocation 38
 + allocation 39
 + allocation 40
 + allocation 41
 + allocation 42
 + allocation 43
 + allocation 44
 + allocation 45
 + allocation 46
 + allocation 47
 + allocation 48
 + allocation 49
 + allocation 50
 + allocation 51
 + allocation 52
 + allocation 53
 + allocation 54
 + allocation 55
 + allocation 56
 + allocation 57
 + allocation 58
 + allocation 59
 + allocation 60
 + allocation 61
 + allocation 62
 + allocation 63
 + allocation 64
 + allocation 65
 + allocation 66
 + allocation 67
 + allocation 68
 + allocation 69
 + allocation 70
 + allocation 71
 + allocation 72
 + allocation 73
 + allocation 74
 + allocation 75
 + allocation 76
 + allocation 77
 + allocation 78
 + allocation 79
 + allocation 80
 + allocation 81
 + allocation 82
 + allocation 83
 + allocation 84
 + allocation 85
 + allocation 86
 + allocation 87
 + allocation 88
 + allocation 89
 + allocation 90
 + allocation 91
 + allocation 92
 + allocation 93
 + allocation 94
 + allocation 95
 + allocation 96
 + allocation 97
 + allocation 98
 + allocation 99
 + free 0
[0] ARMCI assert fail in ARMCI_Free_group() [../src/malloc.c:102]: "mreg != NULL"
[0] Message: "Invalid shared pointer"
[1] ARMCI assert fail in ARMCI_Free_group() [../src/malloc.c:102]: "mreg != NULL"
[1] Message: "Invalid shared pointer"
[0] Backtrace:
[0]   5 - 0   test_malloc                         0x000000010429ed5c ARMCII_Assert_fail + 304
[0]   4 - 1   test_malloc                         0x00000001042a017c ARMCI_Free_group + 116
[0]   3 - 2   test_malloc                         0x00000001042a00fc PARMCI_Free + 32
[0]   2 - 3   test_malloc                         0x00000001042ace64 ARMCI_Free + 24
[0]   1 - 4   test_malloc                         0x000000010429dd18 main + 400
[0]   0 - 5   libdyld.dylib                       0x0000000190875430 start + 4
[1] Backtrace:
[1]   5 - 0   test_malloc                         0x0000000102cb6d5c ARMCII_Assert_fail + 304
[1]   4 - 1   test_malloc                         0x0000000102cb817c ARMCI_Free_group + 116
[1]   3 - 2   test_malloc                         0x0000000102cb80fc PARMCI_Free + 32
[1]   2 - 3   test_malloc                         0x0000000102cc4e64 ARMCI_Free + 24
[1]   1 - 4   test_malloc                         0x0000000102cb5d18 main + 400
[1]   0 - 5   libdyld.dylib                       0x0000000190875430 start + 4
Abort(-1) on node 0 (rank 0 in comm 0): application called MPI_Abort(MPI_COMM_WORLD, -1) - process 0
Abort(-1) on node 1 (rank 1 in comm 0): application called MPI_Abort(MPI_COMM_WORLD, -1) - process 1
```