### PR TITLE
update copyright for Intel to 2019 and add NVIDIA at 2022

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -6,7 +6,8 @@ of the code.
 Copyright (c) 2010-2013 Mathematics and Computer Science, Argonne National Laboratory
 Copyright (c) 2010-2014 Argonne Leadership Computing Facility, Argonne National Laboratory
 Copyright (c) 2010      Futures Laboratory, Oak Ridge National Laboratory
-Copyright (c) 2014-2015 Intel Corporation
+Copyright (c) 2014-2018 Intel Corporation
+Copyright (c) 2022      NVIDIA
 
 Permission is hereby granted to use, reproduce, prepare derivative works, and
 to redistribute to others.


### PR DESCRIPTION
Signed-off-by: Jeff Hammond <jehammond@nvidia.com>