### PR TITLE
Fix the dst addrs in Get inside overlap benchmark

### DIFF
--- a/tests/contrib/non-blocking/overlap.c
+++ b/tests/contrib/non-blocking/overlap.c
@@ -301,7 +301,7 @@ double * benchmark(int op, int msg_size, int size2)
                     time_after_start = MP_TIMER();
 
                     ARMCI_ASSERT(ARMCI_NbGetS(array_ptrs[second], &stride_dist,
-                                array_ptrs[second], &stride_dist,
+                                array_ptrs[rank], &stride_dist,
                                 block_sizes, 1, second, &handle));
                     time_after_call = MP_TIMER();
 


### PR DESCRIPTION
Fix the dst addrs in Get inside contrib/non-blocking/overlap benchmark.

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>

@jeffhammond During our OSC UCX testings we encountered an issue with this test. Please take a look.