### PR TITLE
MPICH info stuff + MPI_Get_library_version

### DIFF
--- a/src/armci_internals.h
+++ b/src/armci_internals.h
@@ -110,7 +110,9 @@ typedef struct {
   int           rma_atomicity;          /* Use Accumulate and Get_accumulate for Put and Get                    */
   int           end_to_end_flush;       /* All flush_local calls become flush                                   */
   int           rma_nocheck;            /* Use MPI_MODE_NOCHECK on synchronization calls that take assertion    */
-  int           disable_shm_accumulate; /* Set the disable_shm_accumulate info key to true                      */
+  int           disable_shm_accumulate; /* Set the disable_shm_accumulate window info key to true               */
+  int           use_same_op;            /* Set accumulate_ops=same_op window info key                           */
+  char          rma_ordering[20];       /* Set accumulate_ordering=<this> window info key                       */
 
   size_t        memory_limit;           /* upper bound on how much memory ARMCI can allocate                    */
 #ifdef HAVE_MEMKIND_H
@@ -144,6 +146,7 @@ char *ARMCII_Getenv(const char *varname);
 int   ARMCII_Getenv_bool(const char *varname, int default_value);
 int   ARMCII_Getenv_int(const char *varname, int default_value);
 long  ARMCII_Getenv_long(const char *varname, long default_value);
+void ARMCII_Getenv_char(char * output, const char *varname, const char *default_value, int length);
 
 /* Synchronization */
 

--- a/src/armci_internals.h
+++ b/src/armci_internals.h
@@ -110,6 +110,7 @@ typedef struct {
   int           rma_atomicity;          /* Use Accumulate and Get_accumulate for Put and Get                    */
   int           end_to_end_flush;       /* All flush_local calls become flush                                   */
   int           rma_nocheck;            /* Use MPI_MODE_NOCHECK on synchronization calls that take assertion    */
+  int           disable_shm_accumulate; /* Set the disable_shm_accumulate info key to true                      */
 
   size_t        memory_limit;           /* upper bound on how much memory ARMCI can allocate                    */
 #ifdef HAVE_MEMKIND_H

--- a/src/init_finalize.c
+++ b/src/init_finalize.c
@@ -64,7 +64,7 @@ static void * progress_function(void * arg)
 #endif /* HAVE_PTHREADS */
 #endif /* ENABLE_PROGRESS */
 
-// Some of these are preprocessor symbols without the namespace...
+/* Some of these are preprocessor symbols without the namespace... */
 enum ARMCII_MPI_Impl_e { ARMCII_MPICH,
                          ARMCII_OPEN_MPI,
                          ARMCII_MVAPICH2,
@@ -99,7 +99,6 @@ static void ARMCII_Parse_library_version(char * library_version, enum ARMCII_MPI
           sprintf(version_string,"%d.%d",major,minor);
           char * p = strstr(library_version,version_string);
           if (p != NULL) {
-            //printf("  MPICH version          = %s (string)\n",p);
             mpich_major = atoi(p);
             mpich_minor = atoi(p+2);
             strncpy(mpich_patch,p+3,4);
@@ -107,8 +106,6 @@ static void ARMCII_Parse_library_version(char * library_version, enum ARMCII_MPI
           }
         }
       }
-      //printf("  MPICH                  = %s\n", is_mpich ? "yes" : "no" );
-      //printf("  MPICH version          = %d.%d%s\n",mpich_major, mpich_minor, mpich_patch);
       *major = mpich_major;
       *minor = mpich_minor;
       strncpy(patch, mpich_patch, sizeof(mpich_patch));
@@ -118,7 +115,7 @@ static void ARMCII_Parse_library_version(char * library_version, enum ARMCII_MPI
       *impl = ARMCII_OPEN_MPI;
       int ompi_major = 0;
       int ompi_minor = 0;
-      char ompi_patch[6] = {0}; // ".PrcX" is max since major=2+
+      char ompi_patch[6] = {0}; /* ".PrcX" is max since major=2+ */
       for (int major = 9; major >= 2; major--) {
         for (int minor = 9; minor >= 0; minor--) {
           char version_string[4] = {0};
@@ -138,8 +135,6 @@ static void ARMCII_Parse_library_version(char * library_version, enum ARMCII_MPI
           }
         }
       }
-      //printf("  Open MPI               = %s\n", is_ompi ? "yes" : "no" );
-      //printf("  Open MPI version       = %d.%d%s\n",ompi_major, ompi_minor, ompi_patch);
       *major = ompi_major;
       *minor = ompi_minor;
       strncpy(patch, ompi_patch, sizeof(ompi_patch));
@@ -180,6 +175,8 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
     }
   }
 
+  ARMCII_GLOBAL_STATE.verbose              = ARMCII_Getenv_bool("ARMCI_VERBOSE", 0);
+
   /* Figure out what MPI library we are using, in an attempt to work around bugs. */
   char mpi_library_version[MPI_MAX_LIBRARY_VERSION_STRING] = {0};
   enum ARMCII_MPI_Impl_e mpi_implementation;
@@ -187,13 +184,12 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
   int mpi_impl_minor = 0;
   char mpi_impl_patch[8] = {0};
   {
-    int len; // unused
+    int len;
     MPI_Get_library_version(mpi_library_version, &len);
-#ifdef DEBUG
-    printf("  MPI library version    = %s\n", mpi_library_version);
-#endif
-    // Only print one line of the version string, since MPICH includes the entire configure invocation.
-    // Truncate after 32 columns since more is rarely useful.
+    if ((ARMCII_GLOBAL_STATE.verbose > 1) && (ARMCI_GROUP_WORLD.rank == 0)) {
+      printf("  MPI library version    = %s\n", mpi_library_version);
+    }
+    /* Truncate after 32 columns of 1 line to simplify parsing. */
     for (int c=0; c<sizeof(mpi_library_version); c++) {
       if (mpi_library_version[c] == '\r' || mpi_library_version[c] == '\n' || c > 32) {
         mpi_library_version[c] = '\0';
@@ -255,7 +251,6 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
       ARMCII_Warning("ARMCI_FLUSH_BARRIERS is deprecated.\n");
     }
   }
-  ARMCII_GLOBAL_STATE.verbose              = ARMCII_Getenv_bool("ARMCI_VERBOSE", 0);
 
   /* Group formation options */
 
@@ -422,7 +417,7 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
       printf("ARMCI-MPI initialized with %d process%s, MPI v%d.%d\n",
              ARMCI_GROUP_WORLD.size, ARMCI_GROUP_WORLD.size > 1 ? "es":"", major, minor);
 
-      // tell user what MPI library they are using
+      /* tell user what MPI library they are using */
       {
         if (mpi_implementation == ARMCII_OPEN_MPI) {
           printf("  Open MPI version       = %d.%d%s\n", mpi_impl_major, mpi_impl_minor, mpi_impl_patch);

--- a/src/init_finalize.c
+++ b/src/init_finalize.c
@@ -175,7 +175,7 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
     }
   }
 
-  ARMCII_GLOBAL_STATE.verbose              = ARMCII_Getenv_int("ARMCI_VERBOSE", 0);
+  ARMCII_GLOBAL_STATE.verbose = ARMCII_Getenv_int("ARMCI_VERBOSE", 0);
 
   /* Figure out what MPI library we are using, in an attempt to work around bugs. */
   char mpi_library_version[MPI_MAX_LIBRARY_VERSION_STRING] = {0};
@@ -352,8 +352,15 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
   /* Pass disable_shm_accumulate=<this> to window constructor */
   ARMCII_GLOBAL_STATE.disable_shm_accumulate=ARMCII_Getenv_bool("ARMCI_DISABLE_SHM_ACC", 0);
 
-  /* Enable RMA element-wise atomicity */
+  /* Pass accumulate_ops = same_op info key to window constructor */
+  ARMCII_GLOBAL_STATE.use_same_op=ARMCII_Getenv_bool("ARMCI_USE_SAME_OP", 0);
+
+  /* Enable RMA element-wise atomicity (affects ARMCI Put/Get) */
   ARMCII_GLOBAL_STATE.rma_atomicity=ARMCII_Getenv_bool("ARMCI_RMA_ATOMICITY", 1);
+
+  /* RMA ordering info key - this is the actual string we pass to MPI */
+  ARMCII_Getenv_char(ARMCII_GLOBAL_STATE.rma_ordering, "ARMCI_RMA_ORDERING", "rar,raw,war,waw",
+                     sizeof(ARMCII_GLOBAL_STATE.rma_ordering)-1);
 
   /* Flush_local becomes flush */
   ARMCII_GLOBAL_STATE.end_to_end_flush=ARMCII_Getenv_bool("ARMCI_NO_FLUSH_LOCAL", 0);
@@ -503,11 +510,13 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
       /* MPI RMA semantics */
       printf("  RMA_ATOMICITY          = %s\n", ARMCII_GLOBAL_STATE.rma_atomicity          ? "TRUE" : "FALSE");
       printf("  NO_FLUSH_LOCAL         = %s\n", ARMCII_GLOBAL_STATE.end_to_end_flush       ? "TRUE" : "FALSE");
+      printf("  RMA_NOCHECK            = %s\n", ARMCII_GLOBAL_STATE.rma_nocheck            ? "TRUE" : "FALSE");
 
       /* MPI info set on window */
-      printf("  RMA_NOCHECK            = %s\n", ARMCII_GLOBAL_STATE.rma_nocheck            ? "TRUE" : "FALSE");
       printf("  USE_ALLOC_SHM          = %s\n", ARMCII_GLOBAL_STATE.use_alloc_shm          ? "TRUE" : "FALSE");
       printf("  DISABLE_SHM_ACC        = %s\n", ARMCII_GLOBAL_STATE.disable_shm_accumulate ? "TRUE" : "FALSE");
+      printf("  USE_SAME_OP            = %s\n", ARMCII_GLOBAL_STATE.use_same_op            ? "TRUE" : "FALSE");
+      printf("  RMA_ORDERING           = %s\n", ARMCII_GLOBAL_STATE.rma_ordering);
 
       /* ARMCI-MPI internal options */
       printf("  IOV_CHECKS             = %s\n", ARMCII_GLOBAL_STATE.iov_checks             ? "TRUE" : "FALSE");

--- a/src/init_finalize.c
+++ b/src/init_finalize.c
@@ -260,8 +260,9 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
   /* Group formation options */
 
   ARMCII_GLOBAL_STATE.cache_rank_translation=ARMCII_Getenv_bool("ARMCI_CACHE_RANK_TRANSLATION", 1);
-  if (ARMCII_Getenv("ARMCI_NONCOLLECTIVE_GROUPS"))
+  if (ARMCII_Getenv("ARMCI_NONCOLLECTIVE_GROUPS")) {
     ARMCII_GLOBAL_STATE.noncollective_groups = ARMCII_Getenv_bool("ARMCI_NONCOLLECTIVE_GROUPS", 0);
+  }
 
   /* Check for IOV flags */
 
@@ -476,9 +477,6 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
           printf("  SHM_LIMIT              = %s\n", "UNLIMITED");
       }
 
-      printf("  ALLOC_SHM used         = %s\n", ARMCII_GLOBAL_STATE.use_alloc_shm ? "TRUE" : "FALSE");
-      printf("  MPI_MODE_NOCHECK used  = %s\n", ARMCII_GLOBAL_STATE.rma_nocheck   ? "TRUE" : "FALSE");
-
       if (ARMCII_GLOBAL_STATE.use_win_allocate == 0) {
           printf("  WINDOW type used       = %s\n", "CREATE");
       }
@@ -506,9 +504,16 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
         }
       }
 
+      /* MPI RMA semantics */
       printf("  RMA_ATOMICITY          = %s\n", ARMCII_GLOBAL_STATE.rma_atomicity          ? "TRUE" : "FALSE");
       printf("  NO_FLUSH_LOCAL         = %s\n", ARMCII_GLOBAL_STATE.end_to_end_flush       ? "TRUE" : "FALSE");
 
+      /* MPI info set on window */
+      printf("  RMA_NOCHECK            = %s\n", ARMCII_GLOBAL_STATE.rma_nocheck            ? "TRUE" : "FALSE");
+      printf("  USE_ALLOC_SHM          = %s\n", ARMCII_GLOBAL_STATE.use_alloc_shm          ? "TRUE" : "FALSE");
+      printf("  DISABLE_SHM_ACC        = %s\n", ARMCII_GLOBAL_STATE.disable_shm_accumulate ? "TRUE" : "FALSE");
+
+      /* ARMCI-MPI internal options */
       printf("  IOV_CHECKS             = %s\n", ARMCII_GLOBAL_STATE.iov_checks             ? "TRUE" : "FALSE");
       printf("  SHR_BUF_METHOD         = %s\n", ARMCII_Shr_buf_methods_str[ARMCII_GLOBAL_STATE.shr_buf_method]);
       printf("  NONCOLLECTIVE_GROUPS   = %s\n", ARMCII_GLOBAL_STATE.noncollective_groups   ? "TRUE" : "FALSE");
@@ -686,8 +691,9 @@ int PARMCI_Finalize(void) {
 
   nfreed = gmr_destroy_all();
 
-  if (nfreed > 0 && ARMCI_GROUP_WORLD.rank == 0)
+  if (nfreed > 0 && ARMCI_GROUP_WORLD.rank == 0) {
     ARMCII_Warning("Freed %d leaked allocations\n", nfreed);
+  }
 
   /* Free GOP operators */
 

--- a/src/init_finalize.c
+++ b/src/init_finalize.c
@@ -353,8 +353,11 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
   /* Poke the MPI progress engine at the end of nonblocking (NB) calls */
   ARMCII_GLOBAL_STATE.explicit_nb_progress=ARMCII_Getenv_bool("ARMCI_EXPLICIT_NB_PROGRESS", 1);
 
-  /* Pass alloc_shm to win_allocate / alloc_mem */
+  /* Pass alloc_shm=<this> to win_allocate / alloc_mem */
   ARMCII_GLOBAL_STATE.use_alloc_shm=ARMCII_Getenv_bool("ARMCI_USE_ALLOC_SHM", 1);
+
+  /* Pass disable_shm_accumulate=<this> to window constructor */
+  ARMCII_GLOBAL_STATE.disable_shm_accumulate=ARMCII_Getenv_bool("ARMCI_DISABLE_SHM_ACC", 0);
 
   /* Enable RMA element-wise atomicity */
   ARMCII_GLOBAL_STATE.rma_atomicity=ARMCII_Getenv_bool("ARMCI_RMA_ATOMICITY", 1);

--- a/src/util.c
+++ b/src/util.c
@@ -185,6 +185,20 @@ long ARMCII_Getenv_long(const char *varname, long default_value) {
   }
 }
 
+/** Retrieve the value of a char environment variable.
+  */
+void ARMCII_Getenv_char(char * output, const char *varname, const char *default_value, int length) {
+  const char *var = getenv(varname);
+  if (var) {
+    if (strlen(var) > length) {
+      ARMCII_Warning("ARMCI_Getenv_char: %s = %s is too long (%d)\n", varname, var, length);
+    }
+    strncpy(output, var, length);
+  } else {
+    strncpy(output, default_value, length);
+  }
+}
+
 void ARMCIX_Progress(void)
 {
     gmr_progress();


### PR DESCRIPTION
Summary:
- query MPI_Get_library_version to help debugging and correctness issues
- add MPICH info keys (e.g. `disable_shm_accumulate`), with env var control where appropriate

@hzhou Can you review this?  It should be very quick.