### PR TITLE
Fix tests

### DIFF
--- a/tests/mpi/test_mpi_accs.c
+++ b/tests/mpi/test_mpi_accs.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
       for (j = 0; j < YDIM; j++) {
         const double actual   = *(buffer + i + j*XDIM);
         const double expected = (1.0 + rank) + (1.0 + ((rank+nranks-1)%nranks)) * (ITERATIONS);
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;

--- a/tests/mpi/test_mpi_indexed_accs.c
+++ b/tests/mpi/test_mpi_indexed_accs.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
       for (j = 0; j < SUB_YDIM; j++) {
         const double actual   = *(win_buf + i + j*XDIM);
         const double expected = (1.0 + rank) + (1.0 + ((rank+nranks-1)%nranks)) * (ITERATIONS);
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
       for (j = 0; j < SUB_YDIM; j++) {
         const double actual   = *(win_buf + i + j*XDIM);
         const double expected = 1.0 + rank;
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
       for (j = SUB_YDIM; j < YDIM; j++) {
         const double actual   = *(win_buf + i + j*XDIM);
         const double expected = 1.0 + rank;
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;

--- a/tests/mpi/test_mpi_indexed_gets.c
+++ b/tests/mpi/test_mpi_indexed_gets.c
@@ -19,7 +19,7 @@
 
 #define XDIM 8
 #define YDIM 1024
-#define SUB_XDIM 8
+#define SUB_XDIM 4
 #define SUB_YDIM 256
 
 int main(int argc, char **argv) {

--- a/tests/mpi/test_mpi_indexed_gets.c
+++ b/tests/mpi/test_mpi_indexed_gets.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
       for (j = 0; j < SUB_YDIM; j++) {
         const double actual   = *(loc_buf + i + j*XDIM);
         const double expected = (1.0 + peer);
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
       for (j = 0; j < SUB_YDIM; j++) {
         const double actual   = *(loc_buf + i + j*XDIM);
         const double expected = 1.0 + rank;
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
       for (j = SUB_YDIM; j < YDIM; j++) {
         const double actual   = *(loc_buf + i + j*XDIM);
         const double expected = 1.0 + rank;
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;

--- a/tests/mpi/test_mpi_indexed_gets.c
+++ b/tests/mpi/test_mpi_indexed_gets.c
@@ -44,8 +44,10 @@ int main(int argc, char **argv) {
     if (rank == 0)
         printf("MPI RMA Strided Get Test:\n");
 
-    for (i = 0; i < XDIM*YDIM; i++)
+    for (i = 0; i < XDIM*YDIM; i++) {
         *(win_buf + i) = 1.0 + rank;
+        *(loc_buf + i) = 1.0 + rank;
+    }
 
     MPI_Win_create(win_buf, bufsize, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &buf_win);
 

--- a/tests/mpi/test_mpi_indexed_puts_gets.c
+++ b/tests/mpi/test_mpi_indexed_puts_gets.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
       for (j = 0; j < SUB_YDIM; j++) {
         const double actual   = *(win_buf + i + j*XDIM);
         const double expected = (1.0 + ((rank+nranks-1)%nranks));
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
       for (j = 0; j < SUB_YDIM; j++) {
         const double actual   = *(win_buf + i + j*XDIM);
         const double expected = 1.0 + rank;
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
       for (j = SUB_YDIM; j < YDIM; j++) {
         const double actual   = *(win_buf + i + j*XDIM);
         const double expected = 1.0 + rank;
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;

--- a/tests/mpi/test_mpi_subarray_accs.c
+++ b/tests/mpi/test_mpi_subarray_accs.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
       for (j = 0; j < SUB_YDIM; j++) {
         const double actual   = *(win_buf + i + j*XDIM);
         const double expected = (1.0 + rank) + (1.0 + ((rank+nranks-1)%nranks)) * (ITERATIONS);
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
       for (j = 0; j < SUB_YDIM; j++) {
         const double actual   = *(win_buf + i + j*XDIM);
         const double expected = 1.0 + rank;
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
       for (j = SUB_YDIM; j < YDIM; j++) {
         const double actual   = *(win_buf + i + j*XDIM);
         const double expected = 1.0 + rank;
-        if (actual - expected > 1e-10) {
+        if (fabs(actual - expected) > 1e-10) {
           printf("%d: Data validation failed at [%d, %d] expected=%f actual=%f\n",
               rank, j, i, expected, actual);
           errors++;


### PR DESCRIPTION
The `test_mpi_indexed_gets` test is currently failing spuriously in debian unstable due to an uninitialized value, e.g. https://ci.debian.net/packages/a/armci-mpi/testing/amd64/44486187/ , preventing the newer mpich version from migrating to unstable.