### PR TITLE
Fix build with -Werror=implicit-function-declaration

### DIFF
--- a/tests/contrib/non-blocking/overlap.c
+++ b/tests/contrib/non-blocking/overlap.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <math.h>
 #include <sys/time.h>
+#include <time.h>
 #include <string.h>
 #include <assert.h>
 

--- a/tests/mpi/test_mpi_accs.c
+++ b/tests/mpi/test_mpi_accs.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 #include <mpi.h>
 
 #define XDIM 1024 

--- a/tests/mpi/test_mpi_indexed_accs.c
+++ b/tests/mpi/test_mpi_indexed_accs.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 #include <mpi.h>
 
 #define XDIM 16

--- a/tests/mpi/test_mpi_indexed_gets.c
+++ b/tests/mpi/test_mpi_indexed_gets.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 #include <mpi.h>
 
 #define XDIM 8

--- a/tests/mpi/test_mpi_indexed_puts_gets.c
+++ b/tests/mpi/test_mpi_indexed_puts_gets.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 #include <mpi.h>
 
 #define XDIM 8

--- a/tests/mpi/test_mpi_subarray_accs.c
+++ b/tests/mpi/test_mpi_subarray_accs.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 #include <mpi.h>
 
 #define XDIM 1024 


### PR DESCRIPTION
Debian started building all packages with
-Werror=implicit-function-declaration, so we now always need proper header includes.