### PR TITLE
update function definition to conform to C23 standard (gcc-15)

### DIFF
--- a/tests/contrib/cg/cg.c
+++ b/tests/contrib/cg/cg.c
@@ -22,7 +22,7 @@ static int niter;
 void read_and_create(int,char **);
 void computeminverser(double *,double *, double *);
 void computeminverse(double *,double *, int *,int *);
-void finalize_arrays();
+void finalize_arrays(int);
 extern void acg_matvecmul(double *,double *,double *,int *,int *);
 extern void acg_addvec(double *,double *,double *,double *, double *);
 extern void acg_2addvec(double *,double *, double *,double *, double *,


### PR DESCRIPTION
gcc-15 uses the C23 language standard as default,
requiring explicit function definitions.

Patch from Matthias Klose
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1096329

Closes: #57