### PR TITLE
fix IOV indexed issues

### DIFF
--- a/src/armci_internals.h
+++ b/src/armci_internals.h
@@ -96,6 +96,7 @@ typedef struct {
   int           debug_alloc;            /* Do extra debuggin on memory allocation                               */
   int           iov_checks;             /* Disable IOV same allocation and overlapping checks                   */
   int           iov_batched_limit;      /* Max number of ops per epoch for BATCHED IOV method                   */
+  int           iov_dtype_chunk;         /* Max blocks per datatype op for DIRECT IOV method (0 = unlimited)     */
   int           noncollective_groups;   /* Use noncollective group creation algorithm                           */
   int           cache_rank_translation; /* Enable caching of translation between absolute and group ranks       */
   int           verbose;                /* ARMCI should produce extra status output                             */

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -102,45 +102,57 @@ int ARMCII_Buf_prepare_acc_vec(void **orig_bufs, void ***new_bufs_ptr, int count
 
   void **new_bufs;
   int i, scaled, num_moved = 0;
-  
-  new_bufs = malloc(count*sizeof(void*));
+
+  /* Allocate count+1 pointer slots.  The extra slot [count] records the base of a
+   * single contiguous MPI_Alloc_mem region when the scaled origin segments are gathered
+   * into one allocation (NULL otherwise), so ARMCII_Buf_finish_acc_vec knows to free one
+   * region instead of count separate ones. */
+  new_bufs = malloc((count+1)*sizeof(void*));
   ARMCII_Assert(new_bufs != NULL);
+  new_bufs[count] = NULL;
 
   scaled = ARMCII_Buf_acc_is_scaled(datatype, scale);
 
-  for (i = 0; i < count; i++) {
-    gmr_t *mreg = NULL;
+  if (scaled) {
+    /* Gather all scaled origin segments into ONE contiguous allocation.  When the
+     * segments live in separate MPI_Alloc_mem regions they can be many GB apart, which
+     * overflows the 32-bit element displacements used by the DIRECT (indexed) IOV
+     * datatype path (ARMCII_Iov_op_datatype); a single allocation keeps every segment
+     * within one small, bounded span. */
+    char *contig;
+    MPI_Alloc_mem((MPI_Aint)count*size, MPI_INFO_NULL, &contig);
+    ARMCII_Assert(contig != NULL);
+    new_bufs[count] = contig;
 
-    // Check if the source buffer is within a shared region.
-    if (ARMCII_GLOBAL_STATE.shr_buf_method != ARMCII_SHR_BUF_NOGUARD)
-      mreg = gmr_lookup(orig_bufs[i], ARMCI_GROUP_WORLD.rank);
-
-    if (scaled) {
-      MPI_Alloc_mem(size, MPI_INFO_NULL, &new_bufs[i]);
-      ARMCII_Assert(new_bufs[i] != NULL);
-
+    for (i = 0; i < count; i++) {
+      new_bufs[i] = contig + (MPI_Aint)i*size;
       ARMCII_Buf_acc_scale(orig_bufs[i], new_bufs[i], size, datatype, scale);
-
-    } else {
-      new_bufs[i] = orig_bufs[i];
     }
+  } else {
+    for (i = 0; i < count; i++) {
+      gmr_t *mreg = NULL;
 
-    if (mreg != NULL) {
-      // If the buffer wasn't copied, we should copy it into a private buffer
-      if (new_bufs[i] == orig_bufs[i]) {
+      // Check if the source buffer is within a shared region.
+      if (ARMCII_GLOBAL_STATE.shr_buf_method != ARMCII_SHR_BUF_NOGUARD)
+        mreg = gmr_lookup(orig_bufs[i], ARMCI_GROUP_WORLD.rank);
+
+      new_bufs[i] = orig_bufs[i];
+
+      if (mreg != NULL) {
+        // The buffer is shared; copy it into a private buffer
         MPI_Alloc_mem(size, MPI_INFO_NULL, &new_bufs[i]);
         ARMCII_Assert(new_bufs[i] != NULL);
 
         ARMCI_Copy(orig_bufs[i], new_bufs[i], size);
       }
-    }
 
-    if (new_bufs[i] == orig_bufs[i])
-      num_moved++;
+      if (new_bufs[i] == orig_bufs[i])
+        num_moved++;
+    }
   }
 
   *new_bufs_ptr = new_bufs;
-  
+
   return num_moved;
 }
 
@@ -157,9 +169,14 @@ int ARMCII_Buf_prepare_acc_vec(void **orig_bufs, void ***new_bufs_ptr, int count
 void ARMCII_Buf_finish_acc_vec(void **orig_bufs, void **new_bufs, int count, int size) {
   int i;
 
-  for (i = 0; i < count; i++) {
-    if (orig_bufs[i] != new_bufs[i]) {
-      MPI_Free_mem(new_bufs[i]);
+  if (new_bufs[count] != NULL) {
+    /* Scaled segments were gathered into a single contiguous allocation. */
+    MPI_Free_mem(new_bufs[count]);
+  } else {
+    for (i = 0; i < count; i++) {
+      if (orig_bufs[i] != new_bufs[i]) {
+        MPI_Free_mem(new_bufs[i]);
+      }
     }
   }
 

--- a/src/init_finalize.c
+++ b/src/init_finalize.c
@@ -293,8 +293,30 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
   /* Max number of blocks packed into a single datatype op in the DIRECT IOV method.
    * 0 = unlimited (one op for all blocks).  Chunking bounds the flattened datatype
    * descriptor so it does not overflow transport limits (e.g. the UCX active-message
-   * header) or trip MPI RMA datatype-accumulate bugs on large operations. */
-  ARMCII_GLOBAL_STATE.iov_dtype_chunk      = ARMCII_Getenv_int("ARMCI_IOV_DTYPE_CHUNK", 0);
+   * header) or trip MPI RMA datatype-accumulate bugs on large operations.
+   *
+   * Implementation-aware default (overridable by ARMCI_IOV_DTYPE_CHUNK):
+   *   Open MPI >= 5 : 1   -- osc/ucx segfaults in ompi_op_reduce when reducing a
+   *                          multi-block datatype Accumulate; a single block per op
+   *                          avoids it.  (OMPI <= 4 handles it, so 0.)
+   *   MPICH/MVAPICH : 256 -- ch4:ucx packs the datatype descriptor into the UCX
+   *                          active-message header, which overflows on IB past ~450
+   *                          blocks; 256 stays well under the limit with good perf,
+   *                          and is harmless on non-UCX/non-IB transports.
+   *   otherwise     : 0
+   */
+#if defined(OPEN_MPI)
+# if (OMPI_MAJOR_VERSION >= 5)
+  const int iov_dtype_chunk_default = 1;
+# else
+  const int iov_dtype_chunk_default = 0;
+# endif
+#elif defined(MPICH_VERSION)
+  const int iov_dtype_chunk_default = 256;
+#else
+  const int iov_dtype_chunk_default = 0;
+#endif
+  ARMCII_GLOBAL_STATE.iov_dtype_chunk      = ARMCII_Getenv_int("ARMCI_IOV_DTYPE_CHUNK", iov_dtype_chunk_default);
   if (ARMCII_GLOBAL_STATE.iov_dtype_chunk < 0) {
     ARMCII_Warning("Ignoring invalid value for ARMCI_IOV_DTYPE_CHUNK (%d)\n", ARMCII_GLOBAL_STATE.iov_dtype_chunk);
     ARMCII_GLOBAL_STATE.iov_dtype_chunk = 0;

--- a/src/init_finalize.c
+++ b/src/init_finalize.c
@@ -290,6 +290,16 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
     ARMCII_GLOBAL_STATE.iov_batched_limit = 0;
   }
 
+  /* Max number of blocks packed into a single datatype op in the DIRECT IOV method.
+   * 0 = unlimited (one op for all blocks).  Chunking bounds the flattened datatype
+   * descriptor so it does not overflow transport limits (e.g. the UCX active-message
+   * header) or trip MPI RMA datatype-accumulate bugs on large operations. */
+  ARMCII_GLOBAL_STATE.iov_dtype_chunk      = ARMCII_Getenv_int("ARMCI_IOV_DTYPE_CHUNK", 0);
+  if (ARMCII_GLOBAL_STATE.iov_dtype_chunk < 0) {
+    ARMCII_Warning("Ignoring invalid value for ARMCI_IOV_DTYPE_CHUNK (%d)\n", ARMCII_GLOBAL_STATE.iov_dtype_chunk);
+    ARMCII_GLOBAL_STATE.iov_dtype_chunk = 0;
+  }
+
 #if defined(OPEN_MPI) && defined(OMPI_MAJOR_VERSION) && (OMPI_MAJOR_VERSION < 5)
   /* Open-MPI 5 RMA works a lot better than older releases... */
   ARMCII_GLOBAL_STATE.iov_method = ARMCII_IOV_BATCHED;
@@ -536,6 +546,13 @@ int PARMCI_Init_thread_comm(int armci_requested, MPI_Comm comm) {
         } else {
           printf("  IOV_BATCHED_LIMIT      = UNLIMITED\n");
         }
+      }
+
+      if (ARMCII_GLOBAL_STATE.iov_method == ARMCII_IOV_DIRECT || ARMCII_GLOBAL_STATE.iov_method == ARMCII_IOV_AUTO) {
+        if (ARMCII_GLOBAL_STATE.iov_dtype_chunk > 0)
+          printf("  IOV_DTYPE_CHUNK        = %d\n", ARMCII_GLOBAL_STATE.iov_dtype_chunk);
+        else
+          printf("  IOV_DTYPE_CHUNK        = UNLIMITED\n");
       }
 
       /* MPI RMA semantics */

--- a/src/vector.c
+++ b/src/vector.c
@@ -297,9 +297,10 @@ int ARMCII_Iov_op_datatype(enum ARMCII_Op_e op, void **src, void **dst, int coun
 
     gmr_t *mreg;
     MPI_Datatype  type_loc, type_rem;
-    MPI_Aint      disp_loc[count];
+    int           disp_loc[count];
     int           disp_rem[count];
     int           block_len[count];
+    MPI_Aint      base_loc;
     void         *dst_win_base;
     int           dst_win_size, i, type_size;
     void        **buf_rem, **buf_loc;
@@ -331,38 +332,45 @@ int ARMCII_Iov_op_datatype(enum ARMCII_Op_e op, void **src, void **dst, int coun
 
     MPI_Get_address(dst_win_base, &base_rem);
 
+    /* Use the first local segment as the origin base so the local datatype can be an
+     * element-indexed (indexed_block) type instead of an absolute-address hindexed type
+     * used from MPI_BOTTOM.  Some MPI RMA implementations mishandle hindexed/MPI_BOTTOM
+     * datatypes in Accumulate; an element-indexed origin (relative to a real buffer, like
+     * the target side already uses) avoids that path. */
+    MPI_Get_address(buf_loc[0], &base_loc);
+
     for (i = 0; i < count; i++) {
-      MPI_Aint target_rem;
-      MPI_Get_address(buf_loc[i], &disp_loc[i]);
+      MPI_Aint target_rem, local_addr;
+      MPI_Get_address(buf_loc[i], &local_addr);
       MPI_Get_address(buf_rem[i], &target_rem);
+      disp_loc[i]  = (local_addr - base_loc)/type_size;   /* element offset from buf_loc[0] */
       disp_rem[i]  = (target_rem - base_rem)/type_size;
       block_len[i] = elem_count;
 
+      ARMCII_Assert_msg((local_addr - base_loc) % type_size == 0, "Local transfer offset is not a multiple of type size");
       ARMCII_Assert_msg((target_rem - base_rem) % type_size == 0, "Transfer size is not a multiple of type size");
       ARMCII_Assert_msg(disp_rem[i] >= 0 && disp_rem[i] < dst_win_size, "Invalid remote pointer");
       ARMCII_Assert_msg(((uint8_t*)buf_rem[i]) + block_len[i] <= ((uint8_t*)dst_win_base) + dst_win_size, "Transfer exceeds buffer length");
     }
 
-    MPI_Type_create_hindexed(count, block_len, disp_loc, type, &type_loc);
+    /* Both origin and target are now element-indexed relative to a real base buffer. */
+    MPI_Type_create_indexed_block(count, elem_count, disp_loc, type, &type_loc);
     MPI_Type_create_indexed_block(count, elem_count, disp_rem, type, &type_rem);
-
-    /* MPI_Type_create_indexed_block should be more efficient than this:
-       MPI_Type_indexed(count, block_len, disp_rem, type, &type_rem); */
 
     MPI_Type_commit(&type_loc);
     MPI_Type_commit(&type_rem);
 
     switch(op) {
       case ARMCII_OP_PUT:
-        gmr_put_typed(mreg, MPI_BOTTOM, 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
+        gmr_put_typed(mreg, buf_loc[0], 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
         flush_local = 1;
         break;
       case ARMCII_OP_GET:
-        gmr_get_typed(mreg, MPI_BOTTOM, 1, type_rem, MPI_BOTTOM, 1, type_loc, proc);
+        gmr_get_typed(mreg, MPI_BOTTOM, 1, type_rem, buf_loc[0], 1, type_loc, proc);
         flush_local = 0;
         break;
       case ARMCII_OP_ACC:
-        gmr_accumulate_typed(mreg, MPI_BOTTOM, 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
+        gmr_accumulate_typed(mreg, buf_loc[0], 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
         flush_local = 1;
         break;
       default:

--- a/src/vector.c
+++ b/src/vector.c
@@ -353,37 +353,45 @@ int ARMCII_Iov_op_datatype(enum ARMCII_Op_e op, void **src, void **dst, int coun
       ARMCII_Assert_msg(((uint8_t*)buf_rem[i]) + block_len[i] <= ((uint8_t*)dst_win_base) + dst_win_size, "Transfer exceeds buffer length");
     }
 
-    /* Both origin and target are now element-indexed relative to a real base buffer. */
-    MPI_Type_create_indexed_block(count, elem_count, disp_loc, type, &type_loc);
-    MPI_Type_create_indexed_block(count, elem_count, disp_rem, type, &type_rem);
+    /* Optionally chunk the blocks across several ops so the flattened datatype
+     * descriptor stays small.  chunk == 0 means one op over all blocks. */
+    int chunk = ARMCII_GLOBAL_STATE.iov_dtype_chunk;
+    if (chunk <= 0 || chunk > count) chunk = count;
 
-    MPI_Type_commit(&type_loc);
-    MPI_Type_commit(&type_rem);
+    for (int start = 0; start < count; start += chunk) {
+      int n = (count - start < chunk) ? (count - start) : chunk;
 
-    switch(op) {
-      case ARMCII_OP_PUT:
-        gmr_put_typed(mreg, buf_loc[0], 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
-        flush_local = 1;
-        break;
-      case ARMCII_OP_GET:
-        gmr_get_typed(mreg, MPI_BOTTOM, 1, type_rem, buf_loc[0], 1, type_loc, proc);
-        flush_local = 0;
-        break;
-      case ARMCII_OP_ACC:
-        gmr_accumulate_typed(mreg, buf_loc[0], 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
-        flush_local = 1;
-        break;
-      default:
-        ARMCII_Error("unknown operation (%d)", op);
-        return 1;
+      /* Both origin and target are element-indexed relative to a real base buffer. */
+      MPI_Type_create_indexed_block(n, elem_count, &disp_loc[start], type, &type_loc);
+      MPI_Type_create_indexed_block(n, elem_count, &disp_rem[start], type, &type_rem);
+      MPI_Type_commit(&type_loc);
+      MPI_Type_commit(&type_rem);
+
+      switch(op) {
+        case ARMCII_OP_PUT:
+          gmr_put_typed(mreg, buf_loc[0], 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
+          flush_local = 1;
+          break;
+        case ARMCII_OP_GET:
+          gmr_get_typed(mreg, MPI_BOTTOM, 1, type_rem, buf_loc[0], 1, type_loc, proc);
+          flush_local = 0;
+          break;
+        case ARMCII_OP_ACC:
+          gmr_accumulate_typed(mreg, buf_loc[0], 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
+          flush_local = 1;
+          break;
+        default:
+          ARMCII_Error("unknown operation (%d)", op);
+          return 1;
+      }
+
+      MPI_Type_free(&type_loc);
+      MPI_Type_free(&type_rem);
     }
 
     if (blocking) {
       gmr_flush(mreg, proc, flush_local);
     }
-
-    MPI_Type_free(&type_loc);
-    MPI_Type_free(&type_rem);
 
     return 0;
 }

--- a/src/vector.c
+++ b/src/vector.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include <armci.h>
 #include <armci_internals.h>
@@ -300,7 +301,9 @@ int ARMCII_Iov_op_datatype(enum ARMCII_Op_e op, void **src, void **dst, int coun
     int           disp_loc[count];
     int           disp_rem[count];
     int           block_len[count];
+    MPI_Aint      loc_addr[count];
     MPI_Aint      base_loc;
+    void         *base_loc_ptr;
     void         *dst_win_base;
     int           dst_win_size, i, type_size;
     void        **buf_rem, **buf_loc;
@@ -332,25 +335,38 @@ int ARMCII_Iov_op_datatype(enum ARMCII_Op_e op, void **src, void **dst, int coun
 
     MPI_Get_address(dst_win_base, &base_rem);
 
-    /* Use the first local segment as the origin base so the local datatype can be an
-     * element-indexed (indexed_block) type instead of an absolute-address hindexed type
-     * used from MPI_BOTTOM.  Some MPI RMA implementations mishandle hindexed/MPI_BOTTOM
-     * datatypes in Accumulate; an element-indexed origin (relative to a real buffer, like
-     * the target side already uses) avoids that path. */
+    /* Build both origin and target as element-indexed (indexed_block) types relative to a
+     * real base buffer, instead of absolute-address hindexed types used from MPI_BOTTOM:
+     * osc/ucx (OMPI4/OMPI5) segfaults when handed an hindexed/MPI_BOTTOM origin datatype in
+     * Accumulate, and an absolute-address target descriptor is large enough to overflow the
+     * ch4:ucx (MPICH) active-message header.  The origin is based at the LOWEST local
+     * segment address so element displacements are non-negative -- the segments are not
+     * necessarily in address order (e.g. the scaled-copy source buffers for ACC).
+     *
+     * indexed_block displacements are 32-bit element offsets.  For a scaled/guarded ACC each
+     * origin segment is a separate MPI_Alloc_mem allocation (ARMCII_Buf_prepare_acc_vec) and
+     * can be arbitrarily far from the base, so assert the element offset fits in a 32-bit int
+     * rather than silently truncating it into a wild address. */
+    base_loc_ptr = buf_loc[0];
     MPI_Get_address(buf_loc[0], &base_loc);
+    for (i = 0; i < count; i++) {
+      MPI_Get_address(buf_loc[i], &loc_addr[i]);
+      if (loc_addr[i] < base_loc) { base_loc = loc_addr[i]; base_loc_ptr = buf_loc[i]; }
+    }
 
     for (i = 0; i < count; i++) {
-      MPI_Aint target_rem, local_addr;
-      MPI_Get_address(buf_loc[i], &local_addr);
+      MPI_Aint target_rem, off_loc;
       MPI_Get_address(buf_rem[i], &target_rem);
-      disp_loc[i]  = (local_addr - base_loc)/type_size;   /* element offset from buf_loc[0] */
-      disp_rem[i]  = (target_rem - base_rem)/type_size;
+      off_loc      = (loc_addr[i] - base_loc)/type_size;  /* element offset from base (>= 0) */
+      disp_rem[i]  = (target_rem - base_rem)/type_size;    /* element offset within the window */
       block_len[i] = elem_count;
 
-      ARMCII_Assert_msg((local_addr - base_loc) % type_size == 0, "Local transfer offset is not a multiple of type size");
+      ARMCII_Assert_msg((loc_addr[i] - base_loc) % type_size == 0, "Local transfer offset is not a multiple of type size");
+      ARMCII_Assert_msg(off_loc <= INT_MAX, "Local segment span exceeds 32-bit element displacement; use ARMCI_IOV_METHOD=BATCHED");
       ARMCII_Assert_msg((target_rem - base_rem) % type_size == 0, "Transfer size is not a multiple of type size");
       ARMCII_Assert_msg(disp_rem[i] >= 0 && disp_rem[i] < dst_win_size, "Invalid remote pointer");
       ARMCII_Assert_msg(((uint8_t*)buf_rem[i]) + block_len[i] <= ((uint8_t*)dst_win_base) + dst_win_size, "Transfer exceeds buffer length");
+      disp_loc[i]  = (int)off_loc;
     }
 
     /* Optionally chunk the blocks across several ops so the flattened datatype
@@ -369,15 +385,15 @@ int ARMCII_Iov_op_datatype(enum ARMCII_Op_e op, void **src, void **dst, int coun
 
       switch(op) {
         case ARMCII_OP_PUT:
-          gmr_put_typed(mreg, buf_loc[0], 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
+          gmr_put_typed(mreg, base_loc_ptr, 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
           flush_local = 1;
           break;
         case ARMCII_OP_GET:
-          gmr_get_typed(mreg, MPI_BOTTOM, 1, type_rem, buf_loc[0], 1, type_loc, proc);
+          gmr_get_typed(mreg, MPI_BOTTOM, 1, type_rem, base_loc_ptr, 1, type_loc, proc);
           flush_local = 0;
           break;
         case ARMCII_OP_ACC:
-          gmr_accumulate_typed(mreg, buf_loc[0], 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
+          gmr_accumulate_typed(mreg, base_loc_ptr, 1, type_loc, MPI_BOTTOM, 1, type_rem, proc);
           flush_local = 1;
           break;
         default:


### PR DESCRIPTION
Numerous issues emerged with this code path on IB.  It doesn't matter to NWChem so we haven't noticed before.  Getting rid of `MPI_BOTTOM` and moving from hindexed to indexed mitigates multiple Open-MPI bugs.  The MPICH issue is weird but is also mitigated with chunking.